### PR TITLE
Add Oozie Eclipse Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ A curated list of amazingly awesome Hadoop and Hadoop ecosystem resources. Inspi
 * [Elephant Bird](https://github.com/kevinweil/elephant-bird) - Twitter's collection of LZO and Protocol Buffer-related Hadoop, Pig, Hive, and HBase code.
 * [Spring for Apache Hadoop](http://projects.spring.io/spring-hadoop/)
 * [hdfs - A native go client for HDFS](https://github.com/colinmarc/hdfs)
+* [Oozie Eclipse Plugin](https://marketplace.eclipse.org/content/oozie-eclipse-plugin) - A graphical editor for editing Apache Oozie workflows inside Eclipse.
 
 ## Realtime Data Processing
 


### PR DESCRIPTION
Oozie Eclipse Plugin is a graphical editor for editing Apache Oozie workflows inside Eclipse. Instead of writing XML files, workflows could be simply created by drag-and-drop in an easy graphical editor.

![image](https://cloud.githubusercontent.com/assets/8685962/9760696/b50158ca-56f7-11e5-82ab-2855b4955f67.png)

![image](https://cloud.githubusercontent.com/assets/8685962/9761974/7aebcdec-5700-11e5-8a5d-e419e9bec015.png)

